### PR TITLE
Update chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE	?= elastic
 TIMEOUT := 1200s
 
 CHART_NAME ?= elastic/elasticsearch
-CHART_VERSION ?= 7.16.3
+CHART_VERSION ?= 7.15.0
 
 DEV_CLUSTER ?= p4-development
 DEV_PROJECT ?= planet-4-151612

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE	?= elastic
 TIMEOUT := 1200s
 
 CHART_NAME ?= elastic/elasticsearch
-CHART_VERSION ?= 7.9.3
+CHART_VERSION ?= 7.16.3
 
 DEV_CLUSTER ?= p4-development
 DEV_PROJECT ?= planet-4-151612

--- a/env/dev/values-client.yaml
+++ b/env/dev/values-client.yaml
@@ -1,8 +1,5 @@
 ---
 resources:
   requests:
-    cpu: 100m
-    memory: 2Gi
-  limits:
-    cpu: 200m
-    memory: 4Gi
+    cpu: 50m
+    memory: 1.5Gi

--- a/env/dev/values-data.yaml
+++ b/env/dev/values-data.yaml
@@ -3,7 +3,4 @@ esJavaOpts: -Xmx2g -Xms2g
 resources:
   requests:
     cpu: 200m
-    memory: 2Gi
-  limits:
-    cpu: 800m
-    memory: 4Gi
+    memory: 2.5Gi

--- a/env/dev/values-data.yaml
+++ b/env/dev/values-data.yaml
@@ -5,5 +5,5 @@ resources:
     cpu: 200m
     memory: 2Gi
   limits:
-    cpu: 400m
+    cpu: 800m
     memory: 4Gi

--- a/env/dev/values-master.yaml
+++ b/env/dev/values-master.yaml
@@ -3,6 +3,3 @@ resources:
   requests:
     cpu: 100m
     memory: 2Gi
-  limits:
-    cpu: 200m
-    memory: 4Gi

--- a/env/prod/values-client.yaml
+++ b/env/prod/values-client.yaml
@@ -1,8 +1,7 @@
 ---
 resources:
   requests:
-    cpu: 200m
-    memory: 2Gi
+    cpu: 50m
+    memory: 1.5Gi
   limits:
-    cpu: 400m
-    memory: 4Gi
+    cpu: 1000m

--- a/env/prod/values-data.yaml
+++ b/env/prod/values-data.yaml
@@ -2,8 +2,7 @@
 esJavaOpts: -Xmx8g -Xms8g
 resources:
   requests:
-    cpu: 1
-    memory: 8Gi
+    cpu: 750m
+    memory: 9Gi
   limits:
-    cpu: 4
     memory: 12Gi

--- a/env/prod/values-data.yaml
+++ b/env/prod/values-data.yaml
@@ -1,9 +1,9 @@
 ---
-esJavaOpts: -Xmx4g -Xms4g
+esJavaOpts: -Xmx8g -Xms8g
 resources:
   requests:
     cpu: 1
-    memory: 4Gi
-  limits:
-    cpu: 2
     memory: 8Gi
+  limits:
+    cpu: 4
+    memory: 12Gi

--- a/env/prod/values-master.yaml
+++ b/env/prod/values-master.yaml
@@ -1,8 +1,5 @@
 ---
 resources:
   requests:
-    cpu: 1
-    memory: 4Gi
-  limits:
-    cpu: 4
-    memory: 8Gi
+    cpu: 250m
+    memory: 2Gi

--- a/env/prod/values-master.yaml
+++ b/env/prod/values-master.yaml
@@ -1,8 +1,8 @@
 ---
 resources:
   requests:
-    cpu: 200m
-    memory: 2Gi
-  limits:
-    cpu: 400m
+    cpu: 1
     memory: 4Gi
+  limits:
+    cpu: 4
+    memory: 8Gi


### PR DESCRIPTION
Update Elasticsearch chart (this doesn't update the image). This is so we can update the API version used by elasticsearch so we don't have problem later with K8S upgrades.

Further @comzeradd where are we at with elasticsearch updates? Where is the image created (looks like a custom p4 one).